### PR TITLE
Conditional Printing of Read More Link on Testimonials Page

### DIFF
--- a/templates/testimonials_page_fields.html.twig
+++ b/templates/testimonials_page_fields.html.twig
@@ -51,6 +51,8 @@
 
 {{ field_testimonial_num_stars }}
 
+{% if fields.view_node %}
 <div class="link-to-content">
   <a href="{{ view_node_link }}" class="emphasized">Read More</a>
 </div>
+{% endif %}


### PR DESCRIPTION
If a link to content field is in the view display for the
testimonials page, the read more link will be printed.
Otherwise, it will not be. This relates to #52.