### PR TITLE
Images Not Printed on Testimonials Page Fix

### DIFF
--- a/google_reviews_testimonials.module
+++ b/google_reviews_testimonials.module
@@ -124,6 +124,21 @@ function google_reviews_testimonials_preprocess_field__field_testimonial_num_sta
 
 }
 
+/**
+ * Only purpose is to add image_set to view templates. Part of a messy solution
+ * that is hopefully going to be replaced by the work in #56.
+ */
+function google_reviews_testimonials_preprocess_views_view_fields(&$variables) {
+
+  if(!empty($variables['fields']['field_testimonial_image']) && 
+  strpos($variables['fields']['field_testimonial_image']->content, 'img') !== FALSE) {
+
+    $variables['image_set'] = TRUE;
+
+  }
+  
+}
+
 function google_reviews_testimonials_preprocess_views_view_field__field_testimonial_num_stars(&$variables) {
   
   if(!empty($variables['row']->_entity->field_testimonial_num_stars->getValue())) {

--- a/templates/testimonials_page_fields.html.twig
+++ b/templates/testimonials_page_fields.html.twig
@@ -1,7 +1,7 @@
-{% if field_testimonial_image %}
+{% if image_set %}
 <div class="testimonials-wrapper-wrapper clearfix with-image">
   <div class="testimonial-img-wrapper">
-    {{ field_testimonial_image }}
+    {{ fields.field_testimonial_image.content }}
   </div> <!-- .testimonial-img-wrapper -->
   
   <div class="testimonial-wrapper">
@@ -24,9 +24,8 @@
     </div> <!-- .attribution-section -->
   </div> <!-- .testimonial-wrapper.with-image -->
 </div>
-{% endif %} 
-  
-{% if not field_testimonial_image %}
+
+{% else %}
 <div class="testimonials-wrapper-wrapper clearfix">
   <div class="testimonial-wrapper">
     <div class="testimonial-body">{{ body }}</div>
@@ -47,7 +46,7 @@
     </div> <!-- .attribution-section -->
   </div> <!-- .testimonial-wrapper --> 
 </div> <!-- .testimonials-wrapper-wrapper -->
-{% endif %}
+{% endif %} 
 
 {{ field_testimonial_num_stars }}
 


### PR DESCRIPTION
This commit fixes #55 wherein images are not printed in the template.
The solution is messy, this is known, but is urgently needed for a
project build. So, a better solution is to be researched in #56.